### PR TITLE
fix qemu key name to org/flatcar-linux

### DIFF
--- a/doc/supported-platforms.md
+++ b/doc/supported-platforms.md
@@ -9,7 +9,7 @@ Ignition is currently only supported for the following platforms:
 * [VMware] - Use the VMware Guestinfo variables `coreos.config.data` and `coreos.config.data.encoding` to provide the config and its encoding to the virtual machine. Valid encodings are "", "base64", and "gzip+base64". Guestinfo variables can be provided directly or via an OVF environment, with priority given to variables specified directly.
 * [Google Compute Engine] - Ignition will read its configuration from the instance metadata entry named "user-data". SSH keys are handled by coreos-metadata.
 * [Packet] - Ignition will read its configuration from the instance userdata. SSH keys are handled by coreos-metadata.
-* [QEMU] - Ignition will read its configuration from the 'opt/com.coreos/config' key on the QEMU Firmware Configuration Device.
+* [QEMU] - Ignition will read its configuration from the 'opt/org.flatcar-linux/config' key on the QEMU Firmware Configuration Device.
 * [DigitalOcean] - Ignition will read its configuration from the droplet userdata. SSH keys and network configuration are handled by coreos-metadata.
 
 Ignition is under active development so expect this list to expand in the coming months.

--- a/internal/providers/qemu/qemu.go
+++ b/internal/providers/qemu/qemu.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // The QEMU provider fetches a local configuration from the firmware config
-// interface (opt/com.coreos/config).
+// interface (opt/org.flatcar-linux/config).
 
 package qemu
 
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	firmwareConfigPath = "/sys/firmware/qemu_fw_cfg/by_name/opt/com.coreos/config/raw"
+	firmwareConfigPath = "/sys/firmware/qemu_fw_cfg/by_name/opt/org.flatcar-linux/config/raw"
 )
 
 func FetchConfig(f resource.Fetcher) (types.Config, report.Report, error) {


### PR DESCRIPTION
To fix a wrong key name when running a qemu VM with ignition, we need to replace `opt/com.coreos` with `opt/org.flatcar-linux`.

Partly addresses https://github.com/flatcar-linux/ignition/issues/2