### PR TITLE
Merge upstream v0.34.0 to flatcar-master

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,20 @@
+11-Dec-2019 IGNITION v0.34.0
+
+  Bug Fixes:
+
+    - Fix bug where AWS region is not set correctly for fetches from s3
+    - Fix bug where empty GPT labels were treated as errors
+
+  Changes:
+
+    - Ignition now logs the name of the stage it is running
+
+  Features:
+
+    - Add optional "fetch" stage to cache the rendered config, but not apply
+      any of it
+    - Add support for aliyun cloud
+
 28-Jun-2019 IGNITION v0.33.0
 
   Bug Fixes:

--- a/internal/exec/engine.go
+++ b/internal/exec/engine.go
@@ -196,7 +196,7 @@ func (e *Engine) fetchProviderConfig() (types.Config, error) {
 	var r report.Report
 	var err error
 	for _, fetcher := range fetchers {
-		cfg, r, err = fetcher(*e.Fetcher)
+		cfg, r, err = fetcher(e.Fetcher)
 		if err != providers.ErrNoProvider {
 			// successful, or failed on another error
 			break

--- a/internal/exec/stages/fetch/fetch.go
+++ b/internal/exec/stages/fetch/fetch.go
@@ -1,0 +1,64 @@
+// Copyright 2019 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The storage stage is responsible for partitioning disks, creating RAID
+// arrays, formatting partitions, writing files, writing systemd units, and
+// writing network units.
+
+package disks
+
+import (
+	"github.com/coreos/ignition/internal/config/types"
+	"github.com/coreos/ignition/internal/exec/stages"
+	"github.com/coreos/ignition/internal/exec/util"
+	"github.com/coreos/ignition/internal/log"
+	"github.com/coreos/ignition/internal/resource"
+)
+
+const (
+	name = "fetch"
+)
+
+func init() {
+	stages.Register(creator{})
+}
+
+type creator struct{}
+
+func (creator) Create(logger *log.Logger, root string, _ resource.Fetcher) stages.Stage {
+	return &stage{
+		Util: util.Util{
+			DestDir: root,
+			Logger:  logger,
+		},
+	}
+}
+
+func (creator) Name() string {
+	return name
+}
+
+type stage struct {
+	util.Util
+}
+
+func (stage) Name() string {
+	return name
+}
+
+func (s stage) Run(_ types.Config) error {
+	// Nothing - all we do is fetch and allow anything else in the initramfs to run
+	s.Logger.Info("fetch complete")
+	return nil
+}

--- a/internal/exec/util/blkid.c
+++ b/internal/exec/util/blkid.c
@@ -174,6 +174,10 @@ static result_t extract_part_info(blkid_partition part, struct partition_info *i
 
 	// label
 	ctmp = blkid_partition_get_name(part);
+	// If the GPT label is empty, then libblkid will return NULL instead of an empty string.
+	// There is no NULL value in GPT, so just reset to empty.
+	if (!ctmp)
+		ctmp = "";
 	err = checked_copy(info->label, ctmp, PART_INFO_BUF_SIZE);
 	if (err)
 		return err;

--- a/internal/main.go
+++ b/internal/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/coreos/ignition/internal/exec"
 	"github.com/coreos/ignition/internal/exec/stages"
 	_ "github.com/coreos/ignition/internal/exec/stages/disks"
+	_ "github.com/coreos/ignition/internal/exec/stages/fetch"
 	_ "github.com/coreos/ignition/internal/exec/stages/files"
 	"github.com/coreos/ignition/internal/log"
 	"github.com/coreos/ignition/internal/oem"

--- a/internal/main.go
+++ b/internal/main.go
@@ -71,6 +71,7 @@ func main() {
 	defer logger.Close()
 
 	logger.Info(version.String)
+	logger.Info("Stage: %v", flags.stage)
 
 	if flags.clearCache {
 		if err := os.Remove(flags.configCache); err != nil {

--- a/internal/oem/oem.go
+++ b/internal/oem/oem.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/coreos/ignition/internal/log"
 	"github.com/coreos/ignition/internal/providers"
+	"github.com/coreos/ignition/internal/providers/aliyun"
 	"github.com/coreos/ignition/internal/providers/azure"
 	"github.com/coreos/ignition/internal/providers/cloudstack"
 	"github.com/coreos/ignition/internal/providers/digitalocean"
@@ -73,6 +74,10 @@ func (c Config) Status(stageName string, f resource.Fetcher, statusErr error) er
 var configs = registry.Create("oem configs")
 
 func init() {
+	configs.Register(Config{
+		name:  "aliyun",
+		fetch: aliyun.FetchConfig,
+	})
 	configs.Register(Config{
 		name:  "azure",
 		fetch: azure.FetchConfig,

--- a/internal/providers/aliyun/aliyun.go
+++ b/internal/providers/aliyun/aliyun.go
@@ -1,0 +1,47 @@
+// Copyright 2019 Red Hat
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The aliyun provider fetches a remote configuration from the
+// aliyun user-data metadata service URL.
+
+package aliyun
+
+import (
+	"net/url"
+
+	"github.com/coreos/ignition/internal/config/types"
+	"github.com/coreos/ignition/internal/providers/util"
+	"github.com/coreos/ignition/internal/resource"
+
+	"github.com/coreos/ignition/config/validate/report"
+)
+
+var (
+	userdataUrl = url.URL{
+		Scheme: "http",
+		Host:   "100.100.100.200",
+		Path:   "latest/user-data",
+	}
+)
+
+func FetchConfig(f *resource.Fetcher) (types.Config, report.Report, error) {
+	data, err := f.FetchToBuffer(userdataUrl, resource.FetchOptions{
+		Headers: resource.ConfigHeaders,
+	})
+	if err != nil && err != resource.ErrNotFound {
+		return types.Config{}, report.Report{}, err
+	}
+
+	return util.ParseConfig(f.Logger, data)
+}

--- a/internal/providers/azure/azure.go
+++ b/internal/providers/azure/azure.go
@@ -51,7 +51,7 @@ const (
 	CDS_DISC_OK
 )
 
-func FetchConfig(f resource.Fetcher) (types.Config, report.Report, error) {
+func FetchConfig(f *resource.Fetcher) (types.Config, report.Report, error) {
 	devicePath := filepath.Join(distro.DiskByIDDir(), configDeviceID)
 
 	logger := f.Logger

--- a/internal/providers/cloudstack/cloudstack.go
+++ b/internal/providers/cloudstack/cloudstack.go
@@ -45,7 +45,7 @@ const (
 	LeaseRetryInterval      = 500 * time.Millisecond
 )
 
-func FetchConfig(f resource.Fetcher) (types.Config, report.Report, error) {
+func FetchConfig(f *resource.Fetcher) (types.Config, report.Report, error) {
 	var data []byte
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 
@@ -191,7 +191,7 @@ func fetchConfigFromDevice(logger *log.Logger, ctx context.Context, label string
 	return ioutil.ReadFile(filepath.Join(mnt, configDriveUserdataPath))
 }
 
-func fetchConfigFromMetadataService(f resource.Fetcher) ([]byte, error) {
+func fetchConfigFromMetadataService(f *resource.Fetcher) ([]byte, error) {
 	addr, err := getDHCPServerAddress()
 	if err != nil {
 		return nil, err

--- a/internal/providers/cmdline/cmdline.go
+++ b/internal/providers/cmdline/cmdline.go
@@ -36,7 +36,7 @@ const (
 	cmdlineUrlFlag       = "ignition.config.url"
 )
 
-func FetchConfig(f resource.Fetcher) (types.Config, report.Report, error) {
+func FetchConfig(f *resource.Fetcher) (types.Config, report.Report, error) {
 	url, err := readCmdline(f.Logger)
 	if err != nil {
 		return types.Config{}, report.Report{}, err

--- a/internal/providers/digitalocean/digitalocean.go
+++ b/internal/providers/digitalocean/digitalocean.go
@@ -34,7 +34,7 @@ var (
 	}
 )
 
-func FetchConfig(f resource.Fetcher) (types.Config, report.Report, error) {
+func FetchConfig(f *resource.Fetcher) (types.Config, report.Report, error) {
 	data, err := f.FetchToBuffer(userdataUrl, resource.FetchOptions{
 		Headers: resource.ConfigHeaders,
 	})

--- a/internal/providers/ec2/ec2.go
+++ b/internal/providers/ec2/ec2.go
@@ -40,7 +40,7 @@ var (
 	}
 )
 
-func FetchConfig(f resource.Fetcher) (types.Config, report.Report, error) {
+func FetchConfig(f *resource.Fetcher) (types.Config, report.Report, error) {
 	data, err := f.FetchToBuffer(userdataUrl, resource.FetchOptions{
 		Headers: resource.ConfigHeaders,
 	})

--- a/internal/providers/ec2/ec2.go
+++ b/internal/providers/ec2/ec2.go
@@ -48,6 +48,13 @@ func FetchConfig(f *resource.Fetcher) (types.Config, report.Report, error) {
 		return types.Config{}, report.Report{}, err
 	}
 
+	// Determine the partition and region this instance is in
+	regionHint, err := ec2metadata.New(f.AWSSession).Region()
+	if err != nil {
+		regionHint = "us-east-1"
+	}
+	f.S3RegionHint = regionHint
+
 	return util.ParseConfig(f.Logger, data)
 }
 
@@ -58,14 +65,8 @@ func NewFetcher(l *log.Logger) (resource.Fetcher, error) {
 	}
 	sess.Config.Credentials = ec2rolecreds.NewCredentials(sess)
 
-	// Determine the partition and region this ec2 is in
-	regionHint, err := ec2metadata.New(sess).Region()
-	if err != nil {
-		regionHint = "us-east-1"
-	}
 	return resource.Fetcher{
-		Logger:       l,
-		AWSSession:   sess,
-		S3RegionHint: regionHint,
+		Logger:     l,
+		AWSSession: sess,
 	}, nil
 }

--- a/internal/providers/file/file.go
+++ b/internal/providers/file/file.go
@@ -29,7 +29,7 @@ const (
 	defaultFilename   = "config.ign"
 )
 
-func FetchConfig(f resource.Fetcher) (types.Config, report.Report, error) {
+func FetchConfig(f *resource.Fetcher) (types.Config, report.Report, error) {
 	filename := os.Getenv(cfgFilenameEnvVar)
 	if filename == "" {
 		filename = defaultFilename

--- a/internal/providers/gce/gce.go
+++ b/internal/providers/gce/gce.go
@@ -36,7 +36,7 @@ var (
 	metadataHeaderVal = "Google"
 )
 
-func FetchConfig(f resource.Fetcher) (types.Config, report.Report, error) {
+func FetchConfig(f *resource.Fetcher) (types.Config, report.Report, error) {
 	headers := resource.ConfigHeaders
 	headers.Set(metadataHeaderKey, metadataHeaderVal)
 	data, err := f.FetchToBuffer(userdataUrl, resource.FetchOptions{

--- a/internal/providers/noop/noop.go
+++ b/internal/providers/noop/noop.go
@@ -23,7 +23,7 @@ import (
 	"github.com/coreos/ignition/internal/resource"
 )
 
-func FetchConfig(f resource.Fetcher) (types.Config, report.Report, error) {
+func FetchConfig(f *resource.Fetcher) (types.Config, report.Report, error) {
 	f.Logger.Debug("noop provider fetching empty config")
 	return types.Config{}, report.Report{}, errors.ErrEmpty
 }

--- a/internal/providers/openstack/openstack.go
+++ b/internal/providers/openstack/openstack.go
@@ -50,7 +50,7 @@ var (
 	}
 )
 
-func FetchConfig(f resource.Fetcher) (types.Config, report.Report, error) {
+func FetchConfig(f *resource.Fetcher) (types.Config, report.Report, error) {
 	var data []byte
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 
@@ -129,7 +129,7 @@ func fetchConfigFromDevice(logger *log.Logger, ctx context.Context, path string)
 	return ioutil.ReadFile(filepath.Join(mnt, configDriveUserdataPath))
 }
 
-func fetchConfigFromMetadataService(f resource.Fetcher) ([]byte, error) {
+func fetchConfigFromMetadataService(f *resource.Fetcher) ([]byte, error) {
 	res, err := f.FetchToBuffer(metadataServiceUrl, resource.FetchOptions{
 		Headers: resource.ConfigHeaders,
 	})

--- a/internal/providers/packet/packet.go
+++ b/internal/providers/packet/packet.go
@@ -51,7 +51,7 @@ var (
 	}
 )
 
-func FetchConfig(f resource.Fetcher) (types.Config, report.Report, error) {
+func FetchConfig(f *resource.Fetcher) (types.Config, report.Report, error) {
 	// Packet's metadata service returns "Not Acceptable" when queried
 	// with the default Accept header.
 	headers := resource.ConfigHeaders

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -27,6 +27,6 @@ var (
 	ErrNoProvider = errors.New("config provider was not online")
 )
 
-type FuncFetchConfig func(f resource.Fetcher) (types.Config, report.Report, error)
+type FuncFetchConfig func(f *resource.Fetcher) (types.Config, report.Report, error)
 type FuncNewFetcher func(logger *log.Logger) (resource.Fetcher, error)
 type FuncPostStatus func(stageName string, f resource.Fetcher, e error) error

--- a/internal/providers/qemu/qemu.go
+++ b/internal/providers/qemu/qemu.go
@@ -32,7 +32,7 @@ const (
 	firmwareConfigPath = "/sys/firmware/qemu_fw_cfg/by_name/opt/com.coreos/config/raw"
 )
 
-func FetchConfig(f resource.Fetcher) (types.Config, report.Report, error) {
+func FetchConfig(f *resource.Fetcher) (types.Config, report.Report, error) {
 	_, err := f.Logger.LogCmd(exec.Command("modprobe", "qemu_fw_cfg"), "loading QEMU firmware config module")
 	if err != nil {
 		return types.Config{}, report.Report{}, err

--- a/internal/providers/system/system.go
+++ b/internal/providers/system/system.go
@@ -42,7 +42,7 @@ func FetchDefaultConfig(logger *log.Logger) (types.Config, report.Report, error)
 	return fetchConfig(logger, defaultFilename)
 }
 
-func FetchConfig(f resource.Fetcher) (types.Config, report.Report, error) {
+func FetchConfig(f *resource.Fetcher) (types.Config, report.Report, error) {
 	return fetchConfig(f.Logger, userFilename)
 }
 

--- a/internal/providers/virtualbox/virtualbox.go
+++ b/internal/providers/virtualbox/virtualbox.go
@@ -35,7 +35,7 @@ const (
 	partUUID = "99570a8a-f826-4eb0-ba4e-9dd72d55ea13"
 )
 
-func FetchConfig(f resource.Fetcher) (types.Config, report.Report, error) {
+func FetchConfig(f *resource.Fetcher) (types.Config, report.Report, error) {
 	f.Logger.Debug("Attempting to read config drive")
 	rawConfig, err := ioutil.ReadFile(filepath.Join(distro.DiskByPartUUIDDir(), partUUID))
 	if os.IsNotExist(err) {

--- a/internal/providers/vmware/vmware_amd64.go
+++ b/internal/providers/vmware/vmware_amd64.go
@@ -29,7 +29,7 @@ import (
 	"github.com/vmware/vmw-ovflib"
 )
 
-func FetchConfig(f resource.Fetcher) (types.Config, report.Report, error) {
+func FetchConfig(f *resource.Fetcher) (types.Config, report.Report, error) {
 	if !vmcheck.IsVirtualWorld() {
 		return types.Config{}, report.Report{}, providers.ErrNoProvider
 	}
@@ -49,7 +49,7 @@ func FetchConfig(f resource.Fetcher) (types.Config, report.Report, error) {
 	return util.ParseConfig(f.Logger, decodedData)
 }
 
-func fetchRawConfig(f resource.Fetcher) (config, error) {
+func fetchRawConfig(f *resource.Fetcher) (config, error) {
 	info := rpcvmx.NewConfig()
 
 	var ovfData string

--- a/internal/providers/vmware/vmware_unsupported.go
+++ b/internal/providers/vmware/vmware_unsupported.go
@@ -27,6 +27,6 @@ import (
 	"github.com/coreos/ignition/internal/resource"
 )
 
-func FetchConfig(_ resource.Fetcher) (types.Config, report.Report, error) {
+func FetchConfig(_ *resource.Fetcher) (types.Config, report.Report, error) {
 	return types.Config{}, report.Report{}, errors.New("vmware provider is not supported on this architecture")
 }

--- a/tests/negative/partitions/zeroes.go
+++ b/tests/negative/partitions/zeroes.go
@@ -29,8 +29,9 @@ func Partition9DoesNotFillDisk() types.Test {
 	name := "Partition 9 is size 0 but does not fill the disk"
 	in := types.GetBaseDisk()
 	in[0].Partitions = append(in[0].Partitions, &types.Partition{
-		Number: 10,
-		Length: 65536,
+		Number:   10,
+		Length:   65536,
+		TypeCode: "blank",
 	})
 	out := in
 	config := `{
@@ -66,8 +67,9 @@ func Partition9DoesNotStartCorrectly() types.Test {
 	//insert a gap before 9
 	tmp := in[0].Partitions[9-2-1]
 	in[0].Partitions[9-2-1] = &types.Partition{
-		Number: 10,
-		Length: 65536,
+		Number:   10,
+		Length:   65536,
+		TypeCode: "blank",
 	}
 	in[0].Partitions = append(in[0].Partitions, tmp)
 	out := in


### PR DESCRIPTION
To address issues like the AWS regions one, we need to merge `v0.34.0` to `flatcar-master`.