### PR TITLE
internal/providers/qemu: Take first successful fw_cfg

### DIFF
--- a/internal/providers/qemu/qemu.go
+++ b/internal/providers/qemu/qemu.go
@@ -49,6 +49,8 @@ func FetchConfig(f *resource.Fetcher) (types.Config, report.Report, error) {
 		} else if err != nil {
 			f.Logger.Err("couldn't read QEMU firmware config %v: %v", path, err)
 			return types.Config{}, report.Report{}, err
+		} else {
+			break
 		}
 	}
 


### PR DESCRIPTION
Add a missing break after opening a config file
successfully.

Note: Need to cherry-pick for alpha/edge.