### PR TITLE
Support coreos.config.url

### DIFF
--- a/internal/providers/cmdline/cmdline.go
+++ b/internal/providers/cmdline/cmdline.go
@@ -32,8 +32,9 @@ import (
 )
 
 const (
-	cmdlineUrlFlagLegacy = "flatcar.config.url"
-	cmdlineUrlFlag       = "ignition.config.url"
+	cmdlineUrlFlagLegacyCoreOS = "coreos.config.url"
+	cmdlineUrlFlagLegacy       = "flatcar.config.url"
+	cmdlineUrlFlag             = "ignition.config.url"
 )
 
 func FetchConfig(f *resource.Fetcher) (types.Config, report.Report, error) {
@@ -84,7 +85,7 @@ func parseCmdline(cmdline []byte) (url string) {
 		parts := strings.SplitN(strings.TrimSpace(arg), "=", 2)
 		key := parts[0]
 
-		if key == cmdlineUrlFlagLegacy || key == cmdlineUrlFlag {
+		if key == cmdlineUrlFlagLegacy || key == cmdlineUrlFlagLegacyCoreOS || key == cmdlineUrlFlag {
 			if len(parts) == 2 {
 				url = parts[1]
 			}


### PR DESCRIPTION
Recognize the coreos.config.url kernel command line
parameter for compatibility.

Note: Create a PR for coreos-overlay after merging (and also pick that for Alpha and Edge when merged).