### PR TITLE
Fix VMware guestinfo variable retrieval and add the missing *.config.url variable

### DIFF
--- a/internal/providers/vmware/vmware_amd64.go
+++ b/internal/providers/vmware/vmware_amd64.go
@@ -18,6 +18,8 @@
 package vmware
 
 import (
+	"net/url"
+
 	"github.com/coreos/ignition/config/validate/report"
 	"github.com/coreos/ignition/internal/config/types"
 	"github.com/coreos/ignition/internal/providers"
@@ -34,28 +36,85 @@ func FetchConfig(f *resource.Fetcher) (types.Config, report.Report, error) {
 		return types.Config{}, report.Report{}, providers.ErrNoProvider
 	}
 
-	config, err := fetchRawConfig(f)
-	if err != nil {
-		return types.Config{}, report.Report{}, err
+	config, err := fetchDataConfig(f)
+	if err == nil && len(config) == 0 {
+		config, err = fetchUrlConfig(f)
 	}
-
-	decodedData, err := decodeConfig(config)
 	if err != nil {
-		f.Logger.Debug("failed to decode config: %v", err)
 		return types.Config{}, report.Report{}, err
 	}
 
 	f.Logger.Debug("config successfully fetched")
-	return util.ParseConfig(f.Logger, decodedData)
+	return util.ParseConfig(f.Logger, config)
 }
 
-func fetchRawConfig(f *resource.Fetcher) (config, error) {
+func fetchDataConfig(f *resource.Fetcher) ([]byte, error) {
+	var data string
+	var encoding string
+	var err error
+
+	data, err = getVariable(f, "ignition.config.data")
+	if err == nil && data != "" {
+		encoding, err = getVariable(f, "ignition.config.data.encoding")
+	} else {
+		data, err = getVariable(f, "coreos.config.data")
+		if err == nil && data != "" {
+			encoding, err = getVariable(f, "coreos.config.data.encoding")
+		}
+	}
+	// Do not check against err from "encoding" because leaving it empty is ok
+	if data == "" {
+		f.Logger.Debug("failed to fetch config")
+		return []byte{}, nil
+	}
+
+	decodedData, err := decodeConfig(config{
+		data:     data,
+		encoding: encoding,
+	})
+	if err != nil {
+		f.Logger.Debug("failed to decode config: %v", err)
+		return nil, err
+	}
+
+	return decodedData, nil
+}
+
+func fetchUrlConfig(f *resource.Fetcher) ([]byte, error) {
+	rawUrl, err := getVariable(f, "ignition.config.url")
+	if err != nil || rawUrl == "" {
+		rawUrl, err = getVariable(f, "coreos.config.url")
+	}
+	if err != nil || rawUrl == "" {
+		f.Logger.Info("no config URL provided")
+		return []byte{}, nil
+	}
+
+	f.Logger.Debug("found url: %q", rawUrl)
+
+	url, err := url.Parse(rawUrl)
+	if err != nil {
+		f.Logger.Err("failed to parse url: %v", err)
+		return nil, err
+	}
+	if url == nil {
+		return []byte{}, nil
+	}
+
+	data, err := f.FetchToBuffer(*url, resource.FetchOptions{
+		Headers: resource.ConfigHeaders,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}
+
+func getVariable(f *resource.Fetcher, key string) (string, error) {
 	info := rpcvmx.NewConfig()
 
 	var ovfData string
-	var ovfEncoding string
-	ovfDataKey := "coreos.config.data"
-	ovfEncodingKey := "coreos.config.data.encoding"
 
 	ovfEnv, err := info.String("ovfenv", "")
 	if err != nil {
@@ -65,31 +124,18 @@ func fetchRawConfig(f *resource.Fetcher) (config, error) {
 		env, err := ovf.ReadEnvironment([]byte(ovfEnv))
 		if err != nil {
 			f.Logger.Warning("failed to parse OVF environment: %v. Continuing...", err)
+		} else {
+			ovfData = env.Properties["guestinfo."+key]
 		}
-
-		if _, ok := env.Properties["guestinfo.ignition.config.data"]; ok {
-			ovfDataKey = "ignition.config.data"
-			ovfEncodingKey = "ignition.config.data.encoding"
-		}
-
-		ovfData = env.Properties["guestinfo."+ovfDataKey]
-		ovfEncoding = env.Properties["guestinfo."+ovfEncodingKey]
 	}
 
-	data, err := info.String(ovfDataKey, ovfData)
+	// The guest variables get preference over the ovfenv variables which are given here as fallback
+	data, err := info.String(key, ovfData)
 	if err != nil {
-		f.Logger.Debug("failed to fetch config: %v", err)
-		return config{}, err
+		f.Logger.Debug("failed to fetch variable, falling back to ovfenv value: %v", err)
+		return ovfData, nil
 	}
 
-	encoding, err := info.String(ovfEncodingKey, ovfEncoding)
-	if err != nil {
-		f.Logger.Debug("failed to fetch config encoding: %v", err)
-		return config{}, err
-	}
-
-	return config{
-		data:     data,
-		encoding: encoding,
-	}, nil
+	// An empty string will be returned if nothing was found
+	return data, nil
 }


### PR DESCRIPTION
- VMware: Fix `guestinfo.*.config.data` variable retrieval
    The decision whether to use `ignition.config.data` or `coreos.config.data`
    was based on their presence in ovfenv. If this was missing, `coreos.config.data`
    would always be used. Also, if the retrieval of the guestinfo would have an error,
    the value from ovfenv would not be used even though it was supposed to be a fallback.
    Refactor the logic to get variables from the ovfenv as fallback while preferring the
    direct guestinfo variables. With this new function, fix the logic of falling back to
    `coreos.config.data` but preferring `ignition.config.data`.
- VMware: Add support for `*.config.url` which was missing
    The OVF metadata for CoreOS specified `guestinfo.coreos.config.url` but that was
    never used to fetch the Ignition config.
    Use `guestinfo.*.config.url` as fallback if no `guestinfo.*.config.data` variables are set.

# How to use
Enter an SDK and point the Ignition ebuild to this commit.
Then build the image:

```
$ emerge-amd64-usr -1 ignition
$ emerge-amd64-usr -1 coreos-kernel
$ ./build_image
$ ./image_to_vm.sh … --format=vmware_ova
```

Create a VM from the image in, e.g., VMware ESXi via `ovftool` and via the web UI. Either specify the `coreos.config.url` or `ignition.config.url` variable to point to an Ignition file served via HTTP, or specify `coreos.config.data` and `coreos.config.data.encoding` or `ignition.config.data` and `ignition.config.data.encoding` (a valid encoding is, e.g., `base64` with the data being converted via `cat ignition.json | base64 --wrap=0`).

# Testing done

Tested locally and on ESXi.

I will also file an upstream PR if possible (but upstream master does not have fallback to `coreos*` variables).