### PR TITLE
oem: Add Vultr as a provider

### DIFF
--- a/internal/oem/oem.go
+++ b/internal/oem/oem.go
@@ -32,6 +32,7 @@ import (
 	"github.com/coreos/ignition/internal/providers/qemu"
 	"github.com/coreos/ignition/internal/providers/virtualbox"
 	"github.com/coreos/ignition/internal/providers/vmware"
+	"github.com/coreos/ignition/internal/providers/vultr"
 	"github.com/coreos/ignition/internal/registry"
 	"github.com/coreos/ignition/internal/resource"
 )
@@ -155,6 +156,10 @@ func init() {
 	configs.Register(Config{
 		name:  "vmware",
 		fetch: vmware.FetchConfig,
+	})
+	configs.Register(Config{
+		name:  "vultr",
+		fetch: vultr.FetchConfig,
 	})
 	configs.Register(Config{
 		name:  "interoute",

--- a/internal/providers/vultr/vultr.go
+++ b/internal/providers/vultr/vultr.go
@@ -1,0 +1,47 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The vultr provider fetches a remote configuration from the vultr
+// user-data metadata service URL.
+// https://web.archive.org/web/20190513194756/https://www.vultr.com/metadata/#user
+
+package vultr
+
+import (
+	"net/url"
+
+	"github.com/coreos/ignition/config/validate/report"
+	"github.com/coreos/ignition/internal/config/types"
+	"github.com/coreos/ignition/internal/providers/util"
+	"github.com/coreos/ignition/internal/resource"
+)
+
+var (
+	userdataUrl = url.URL{
+		Scheme: "http",
+		Host:   "169.254.169.254",
+		Path:   "latest/user-data",
+	}
+)
+
+func FetchConfig(f *resource.Fetcher) (types.Config, report.Report, error) {
+	data, err := f.FetchToBuffer(userdataUrl, resource.FetchOptions{
+		Headers: resource.ConfigHeaders,
+	})
+	if err != nil {
+		return types.Config{}, report.Report{}, err
+	}
+
+	return util.ParseConfig(f.Logger, data)
+}


### PR DESCRIPTION
* added vultr to oem reg

cc @eb3095
ref https://github.com/eb3095/ignition/pull/2

Co-authored-by: Mike Biondi <biondizzle@gmail.com>
Co-authored-by: eb3095 <45504889+eb3095@users.noreply.github.com>
Signed-off-by: Vincent Batts <vbatts@kinvolk.io>

# oem: Add Vultr as a provider

# How to use

`./bin/amd64/ignition -oem vultr ...`


# Testing done

Have not
