### PR TITLE
internal/exec: fix package name to fetch

### DIFF
--- a/internal/exec/stages/fetch/fetch.go
+++ b/internal/exec/stages/fetch/fetch.go
@@ -16,7 +16,7 @@
 // arrays, formatting partitions, writing files, writing systemd units, and
 // writing network units.
 
-package disks
+package fetch
 
 import (
 	"github.com/coreos/ignition/internal/config/types"


### PR DESCRIPTION
# [Title: describe the change in one sentence]

fixes an incorrect package name

# How to use

run existing unit/integration tests

# Testing done

none