### PR TITLE
doc: specify the expected kernel parameters

### DIFF
--- a/doc/supported-platforms.md
+++ b/doc/supported-platforms.md
@@ -2,11 +2,11 @@
 
 Ignition is currently only supported for the following platforms:
 
-* [Bare Metal] - Use the `coreos.config.url` kernel parameter to provide a URL to the configuration. The URL can use the `http://`, `https://`, `tftp://`, or `s3://` schemes to specify a remote config or the `oem://` scheme to specify a local config, rooted in `/usr/share/oem`.
-* [PXE] - Use the `coreos.config.url` and `coreos.first_boot=1` (**in case of the very first PXE boot only**) kernel parameters to provide a URL to the configuration. The URL can use the `http://`, `https://`, `tftp://`, or `s3://` schemes to specify a remote config or the `oem://` scheme to specify a local config, rooted in `/usr/share/oem`.
+* [Bare Metal] - Use the `ignition.config.url` kernel parameter to provide a URL to the configuration (also `flatcar.config.url` OR `coreos.config.url` are accepted). The URL can use the `http://`, `https://`, `tftp://`, or `s3://` schemes to specify a remote config or the `oem://` scheme to specify a local config, rooted in `/usr/share/oem`.
+* [PXE] - Use the `ignition.config.url` and `flatcar.first_boot=1` (**in case of the very first PXE boot only**) kernel parameters to provide a URL to the configuration (also `flatcar.config.url` OR `coreos.config.url`, and `coreos.first_boot=1` are accepted). The URL can use the `http://`, `https://`, `tftp://`, or `s3://` schemes to specify a remote config or the `oem://` scheme to specify a local config, rooted in `/usr/share/oem`.
 * [Amazon EC2] - Ignition will read its configuration from the instance userdata. SSH keys are handled by coreos-metadata.
 * [Microsoft Azure] - Ignition will read its configuration from the custom data provided to the instance. SSH keys are handled by the Azure Linux Agent.
-* [VMware] - Use the VMware Guestinfo variables `coreos.config.data` and `coreos.config.data.encoding` to provide the config and its encoding to the virtual machine. Valid encodings are "", "base64", and "gzip+base64". Guestinfo variables can be provided directly or via an OVF environment, with priority given to variables specified directly.
+* [VMware] - Use the VMware Guestinfo variables `ignition.config.data` and `ignition.config.data.encoding` to provide the config and its encoding to the virtual machine (also `coreos.config.data` and `coreos.config.data.encoding` are accepted). Valid encodings are "", "base64", and "gzip+base64". Guestinfo variables can be provided directly or via an OVF environment, with priority given to variables specified directly.
 * [Google Compute Engine] - Ignition will read its configuration from the instance metadata entry named "user-data". SSH keys are handled by coreos-metadata.
 * [Packet] - Ignition will read its configuration from the instance userdata. SSH keys are handled by coreos-metadata.
 * [QEMU] - Ignition will read its configuration from the 'opt/org.flatcar-linux/config' key on the QEMU Firmware Configuration Device.


### PR DESCRIPTION
the `coreos.` prefixed parameters are legacy. There are others allowed
and prefered.

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>
