### PR TITLE
removed the broken link to the online validator

### DIFF
--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -43,7 +43,7 @@ In cases where the machine fails to boot, it's sometimes helpful to ask journald
 
 ### Validating the Configuration
 
-One common cause for Ignition failures is a malformed configuration (e.g. a misspelled section or incorrect hierarchy). Ignition will log errors, warnings, and other notes about the configuration that it parsed, so this can be used to debug issues with the configuration provided. As a convenience, CoreOS hosts an [online validator][validator] which can be used to quickly verify configurations.
+One common cause for Ignition failures is a malformed configuration (e.g. a misspelled section or incorrect hierarchy). Ignition will log errors, warnings, and other notes about the configuration that it parsed, so this can be used to debug issues with the configuration provided. You can host your own validator by building the [offline validator][validator] which can be used to quickly verify configurations.
 
 ### Enabling systemd Services
 
@@ -58,4 +58,4 @@ Ignition is not typically run more than once during a machine's lifetime in a gi
 [platforms]: supported-platforms.md
 [preset]: https://www.freedesktop.org/software/systemd/man/systemd.preset.html
 [troubleshooting]: #troubleshooting
-[validator]: https://coreos.com/validate
+[validator]: https://github.com/kinvolk/container-linux-userdata-validator


### PR DESCRIPTION
# documentation change
The link to https://coreos.com/validate is not valid anymore. Redirect folks to the kinfolk validator repo


## How to use
This is needed to remove links to old coreos tools/code. 

## Testing done
I tested the link to the github repo
