### PR TITLE
internal/resource/url: support btrfs as OEM partition filesystem

### DIFF
--- a/internal/resource/url.go
+++ b/internal/resource/url.go
@@ -475,8 +475,17 @@ func (f *Fetcher) mountOEM(oemMountPath string) error {
 		},
 		"mounting %q at %q", distro.OEMDevicePath(), oemMountPath,
 	); err != nil {
-		return fmt.Errorf("failed to mount device %q at %q: %v",
+		f.Logger.Err("failed to mount ext4 device %q at %q, trying btrfs: %v",
 			distro.OEMDevicePath(), oemMountPath, err)
+		if err := f.Logger.LogOp(
+			func() error {
+				return syscall.Mount(dev[0], oemMountPath, "btrfs", 0, "")
+			},
+			"mounting %q at %q", distro.OEMDevicePath(), oemMountPath,
+		); err != nil {
+			return fmt.Errorf("failed to mount btrfs device %q at %q: %v",
+				distro.OEMDevicePath(), oemMountPath, err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
When btrfs is used to fit more content into the partition, mounting
fails because ext4 was hardcoded.
When mounting ext4 fails, try mounting as btrfs.

## How to use/testing done

This was built and tested with the coreos-overlay branch `kai/bootengine-verity-hashoffset` from https://github.com/kinvolk/coreos-overlay/pull/1106 and flatcar-scripts branch `kai/btrfs-usr-oem` from https://github.com/kinvolk/flatcar-scripts/pull/131 in http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/3029/cldsv/ where the Flatcar image that has a btrfs /usr partition and OEM partition.
While the actual switch to a btrfs filesystem on the /usr partition is only possible when all changes are part of a Stable release because update-engine needs to know how to handle the new filesystem when updating, we can already do the switch for the OEM partition.