### PR TITLE
Ignore filesystem format mismatches for the OEM partition

### DIFF
--- a/internal/exec/stages/disks/filesystems.go
+++ b/internal/exec/stages/disks/filesystems.go
@@ -108,7 +108,7 @@ func (s stage) createFilesystem(fs types.Mount) error {
 		// If the filesystem isn't forcefully being created, then we need
 		// to check if it is of the correct type or that no filesystem exists.
 
-		if info.format == fs.Format &&
+		if (info.format == fs.Format || (info.label == "OEM" && *fs.Label == "OEM")) &&
 			(fs.Label == nil || info.label == *fs.Label) &&
 			(fs.UUID == nil || canonicalizeFilesystemUUID(info.format, info.uuid) == canonicalizeFilesystemUUID(fs.Format, *fs.UUID)) {
 			s.Logger.Info("filesystem at %q is already correctly formatted. Skipping mkfs...", fs.Device)


### PR DESCRIPTION
- As soon as the OEM partition's filesystem format changes, all users
    that have file entries for the OEM partition (e.g., for kernel
    parameters), need to also switch to the new format, otherwise Ignition
    will bootloop due to the encountered mismatch error. If users have set
    the wipeFilesystem option there is no change in behavior and the user
    would create the desired filesystem on each Ignition run.
    
    To spare the users the migration due to an internal detail of the OEM
    partition, allow the OEM filesystem format to mismatch and just reuse
    the existing OEM partition. The user can still enable the
    wipeFilesystem to reformat regardless what content the partition has.
- Try all formats when mounting filesystems to write files
    
    The filesystem to mount is either newly created by Ignition or reused
    because the specification matches. That means Ignition knows the
    filesystem and can use a single mount system call. However, if we want
    to allow reusing existing filesystems with a different format, it would
    be better to have a mount behavior like the mount utility has that
    tries all filesystems until success.
    
    Try all allowed formats when mounting filesystems to write files. Due
    to the specification and the validator existing filesystems that are
    not in the hardcoded list are rejected anyway and we don't need to
    query more dynamically.


## How to use

Use a mismatching filesystem format in the following spec compared to the existing OEM partition. The system should not bootloop.

Image with a btrfs OEM partition: https://storage.googleapis.com/flatcar-jenkins/developer/developer/boards/amd64-usr/2021.07.30+dev-flatcar-master-3173/flatcar_production_image.bin.bz2

```
{
  "ignition": {
    "config": {},
    "security": {
      "tls": {}
    },
    "timeouts": {},
    "version": "2.3.0"
  },
  "networkd": {},
  "passwd": {},
  "storage": {
    "files": [
      {
        "filesystem": "oem",
        "path": "/grub.cfg",
        "contents": {
          "source": "data:,set%20linux_append%3D%22flatcar.autologin%22%0A",
          "verification": {}
        },
        "mode": 420
      }
    ],
    "filesystems": [
      {
        "mount": {
          "device": "/dev/disk/by-label/OEM",
          "format": "ext4",
          "label": "OEM"
        },
        "name": "oem"
      }
    ]
  },
  "systemd": {}
}
```

## Testing done

Built a btrfs OEM image with this patch in http://localhost:9091/job/os/job/manifest/3173/cldsv/ (but the revert to ext4 was merged before the vm-matrix job was run, so that failed) and verified that the above works by first trying to mount ext4, then btrfs for the OEM partition.