### PR TITLE
support Azure generation 2 VMs

### DIFF
--- a/internal/distro/distro.go
+++ b/internal/distro/distro.go
@@ -23,7 +23,6 @@ import (
 // -X github.com/coreos/ignition/internal/distro.mdadmCmd=/opt/bin/mdadm
 var (
 	// Device node directories and paths
-	diskByIDDir       = "/dev/disk/by-id"
 	diskByLabelDir    = "/dev/disk/by-label"
 	diskByPartUUIDDir = "/dev/disk/by-partuuid"
 	oemDevicePath     = "/dev/disk/by-label/OEM"
@@ -59,7 +58,6 @@ var (
 	blackboxTesting = "false"
 )
 
-func DiskByIDDir() string       { return diskByIDDir }
 func DiskByLabelDir() string    { return diskByLabelDir }
 func DiskByPartUUIDDir() string { return diskByPartUUIDDir }
 func OEMDevicePath() string     { return fromEnv("OEM_DEVICE", oemDevicePath) }

--- a/internal/exec/util/blkid.c
+++ b/internal/exec/util/blkid.c
@@ -19,6 +19,12 @@
 static inline void _free_probe(blkid_probe *pr) { if (pr) blkid_free_probe(*pr); }
 #define _cleanup_probe_ __attribute__((cleanup(_free_probe)))
 
+static inline void _free_cache(blkid_cache *gcache) { blkid_put_cache(*gcache); }
+#define _cleanup_cache_ __attribute__((cleanup(_free_cache)))
+
+static inline void _free_iterator(blkid_dev_iterate *iter) { blkid_dev_iterate_end(*iter); }
+#define _cleanup_iterator_ __attribute__((cleanup(_free_iterator)))
+
 static result_t extract_part_info(blkid_partition part, struct partition_info *info, long sector_divisor);
 
 static result_t checked_copy(char *dest, const char *src, size_t len);
@@ -212,5 +218,40 @@ static result_t extract_part_info(blkid_partition part, struct partition_info *i
 		return RESULT_LOOKUP_FAILED;
 	info->size = itmp / sector_divisor;
 
+	return RESULT_OK;
+}
+
+// blkid_get_block_devices fetches block devices with the given FSTYPE
+result_t blkid_get_block_devices(const char *fstype, struct block_device_list *device) {
+	blkid_dev_iterate iter _cleanup_iterator_ = NULL;
+	blkid_dev dev;
+	blkid_cache cache _cleanup_cache_ = NULL;
+	int err, count = 0;
+	const char *ctmp;
+	
+	if (blkid_get_cache(&cache, "/dev/null") != 0)
+		return RESULT_GET_CACHE_FAILED;
+	
+	if (blkid_probe_all(cache) != 0)
+		return RESULT_PROBE_FAILED;
+
+	iter = blkid_dev_iterate_begin(cache);
+	
+	blkid_dev_set_search(iter, "TYPE", fstype);
+	
+	while (blkid_dev_next(iter, &dev) == 0) {
+		dev = blkid_verify(cache, dev);
+		if (!dev)
+			continue;
+		if (count >= MAX_BLOCK_DEVICES)
+			return RESULT_MAX_BLOCK_DEVICES;
+		ctmp = blkid_dev_devname(dev);
+		err = checked_copy(device->path[count], ctmp, MAX_BLOCK_DEVICE_PATH_LEN);
+		if (err)
+			return err;
+		count++;
+	}
+	
+	device->count = count;
 	return RESULT_OK;
 }

--- a/internal/exec/util/blkid.h
+++ b/internal/exec/util/blkid.h
@@ -25,10 +25,12 @@ typedef enum {
 	RESULT_NO_PARTITION_TABLE,
 	RESULT_BAD_INDEX,
 	RESULT_GET_PARTLIST_FAILED,
+	RESULT_GET_CACHE_FAILED,
 	RESULT_DISK_HAS_NO_TYPE,
 	RESULT_DISK_NOT_GPT,
 	RESULT_BAD_PARAMS,
 	RESULT_OVERFLOW,
+	RESULT_MAX_BLOCK_DEVICES,
 	RESULT_NO_TOPO,
 	RESULT_NO_SECTOR_SIZE,
 	RESULT_BAD_SECTOR_SIZE,
@@ -46,6 +48,14 @@ struct partition_info {
 	int number;
 };
 
+#define MAX_BLOCK_DEVICES 10
+#define MAX_BLOCK_DEVICE_PATH_LEN 50
+
+struct block_device_list {
+	char path[MAX_BLOCK_DEVICES][MAX_BLOCK_DEVICE_PATH_LEN];
+	int count;
+};
+
 result_t blkid_lookup(const char *device, const char *field_name, char buf[], size_t buf_len);
 
 result_t blkid_get_num_partitions(const char *device, int *ret);
@@ -53,5 +63,6 @@ result_t blkid_get_num_partitions(const char *device, int *ret);
 // WARNING part_num may not be what you expect. see the .c file's comment for why
 result_t blkid_get_partition(const char *device, int part_num, struct partition_info *info);
 
-#endif // _BLKID_H_
+result_t blkid_get_block_devices(const char *fstype, struct block_device_list *device);
 
+#endif // _BLKID_H_


### PR DESCRIPTION
# support Azure generation 2 VMs

Azure generation 2 VMs present the configuration DVD in a slightly different way so ignition needed adaptation. The provisioning contract is documented here https://docs.microsoft.com/en-us/azure/virtual-machines/linux/provisioning. After this change ignition scans all block devices that match the configuration DVD filesystem and searches for the provisioning data.

This is a backport of this upstream PR https://github.com/coreos/ignition/pull/1241.

## How to use

```bash
./build_image
./image_to_vm --format=azure
azure-vhd-utils upload ...
az image create ... --name flatcar_azure_gen2 --hyper-v-generation V2
az vm create ... --image flatcar_azure_gen2
```

## Testing done

Checked that VM boots and hostname + ssh_authorized_keys gets populated. Kola to follow to verify that nothing breaks.
