### PR TITLE
Fix null pointer deref crash when no OEM filesystem label is specified

### DIFF
--- a/internal/exec/stages/disks/filesystems.go
+++ b/internal/exec/stages/disks/filesystems.go
@@ -108,7 +108,7 @@ func (s stage) createFilesystem(fs types.Mount) error {
 		// If the filesystem isn't forcefully being created, then we need
 		// to check if it is of the correct type or that no filesystem exists.
 
-		if (info.format == fs.Format || (info.label == "OEM" && *fs.Label == "OEM")) &&
+		if (info.format == fs.Format || info.label == "OEM") &&
 			(fs.Label == nil || info.label == *fs.Label) &&
 			(fs.UUID == nil || canonicalizeFilesystemUUID(info.format, info.uuid) == canonicalizeFilesystemUUID(fs.Format, *fs.UUID)) {
 			s.Logger.Info("filesystem at %q is already correctly formatted. Skipping mkfs...", fs.Device)


### PR DESCRIPTION
The check for reusing a filesystem didn't cover the case where no
filesystem label was specified for the OEM partition, causing a crash.

Instead of handling the missing filesystem labels in the check when an
    existing OEM partition is checked for reuse, we relax the conditions
    for reuse of the OEM partition and will always reuse it unless a
    mismatching FS label or UUID got specified by the user (and the user
    doesn't force a wipe).


## How to use

Test that a CLC with

```
storage:
  filesystems:
     - name: oem
       mount:
         device: "/dev/disk/by-label/OEM"
         format: "btrfs"
  files:
    - path: /grub.cfg
      filesystem: oem
      mode: 0644
      contents:
        inline: |
          set linux_append="flatcar.autologin"
```
which is missing the label `label: OEM` does not crash the system but reuses the existing OEM partition to write to the file.
With `ext4` there is a mismatch and the system is expected to reuse the partition, too, and not enter a bootloop.

## Testing done

Tested these three cases:
```
==> ignition-oem-grub-cfg2.yaml <==
storage:
  filesystems:
     - name: oem
       mount:
         device: "/dev/disk/by-label/OEM"
         format: "btrfs"
  files:
    - path: /grub.cfg
      filesystem: oem
      mode: 0644
      contents:
        inline: |
          set linux_append="flatcar.autologin"

==> ignition-oem-grub-cfg3.yaml <==
storage:
  filesystems:
     - name: oem
       mount:
         device: "/dev/disk/by-label/OEM"
         format: "ext4"
  files:
    - path: /grub.cfg
      filesystem: oem
      mode: 0644
      contents:
        inline: |
          set linux_append="flatcar.autologin"

==> ignition-oem-grub-cfg.yaml <==
storage:
  filesystems:
    - name: oem
      mount:
        device: /dev/disk/by-label/OEM
        format: ext4
        label: OEM
  files:
    - path: /grub.cfg
      filesystem: oem
      mode: 0644
      contents:
        inline: |
          set linux_append="flatcar.autologin"
```