### PR TITLE
Update dataurl module to v1.0.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/sigma/vmw-guestinfo v0.0.0-20160204083807-95dd4126d6e8
 	github.com/smartystreets/goconvey v1.7.2 // indirect
 	github.com/stretchr/testify v1.7.0
-	github.com/vincent-petithory/dataurl v0.0.0-20160330182126-9a301d65acbb
+	github.com/vincent-petithory/dataurl v1.0.0
 	github.com/vmware/vmw-guestinfo v0.0.0-20170707015358-25eff159a728 // indirect
 	github.com/vmware/vmw-ovflib v0.0.0-20170608004843-1f217b9dc714
 	go4.org v0.0.0-20160314031811-03efcb870d84

--- a/go.sum
+++ b/go.sum
@@ -35,8 +35,8 @@ github.com/smartystreets/goconvey v1.7.2/go.mod h1:Vw0tHAZW6lzCRk3xgdin6fKYcG+G3
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/vincent-petithory/dataurl v0.0.0-20160330182126-9a301d65acbb h1:lyL3z7vYwTWXf4/bI+A01+cCSnfhKIBhy+SQ46Z/ml8=
-github.com/vincent-petithory/dataurl v0.0.0-20160330182126-9a301d65acbb/go.mod h1:FHafX5vmDzyP+1CQATJn7WFKc9CvnvxyvZy6I1MrG/U=
+github.com/vincent-petithory/dataurl v1.0.0 h1:cXw+kPto8NLuJtlMsI152irrVw9fRDX8AbShPRpg2CI=
+github.com/vincent-petithory/dataurl v1.0.0/go.mod h1:FHafX5vmDzyP+1CQATJn7WFKc9CvnvxyvZy6I1MrG/U=
 github.com/vmware/vmw-guestinfo v0.0.0-20170707015358-25eff159a728 h1:sH9mEk+flyDxiUa5BuPiuhDETMbzrt9A20I2wktMvRQ=
 github.com/vmware/vmw-guestinfo v0.0.0-20170707015358-25eff159a728/go.mod h1:x9oS4Wk2s2u4tS29nEaDLdzvuHdB19CvSGJjPgkZJNk=
 github.com/vmware/vmw-ovflib v0.0.0-20170608004843-1f217b9dc714 h1:wJqF3m4Tj8I4beSi6vGxIyNtsq6wwGqhK3UnA99ltL4=

--- a/vendor/github.com/vincent-petithory/dataurl/dataurl.go
+++ b/vendor/github.com/vincent-petithory/dataurl/dataurl.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 )
@@ -44,8 +45,18 @@ func (mt *MediaType) ContentType() string {
 //
 // Params values are escaped with the Escape function, rather than in a quoted string.
 func (mt *MediaType) String() string {
-	var buf bytes.Buffer
-	for k, v := range mt.Params {
+	var (
+		buf  bytes.Buffer
+		keys = make([]string, len(mt.Params))
+		i    int
+	)
+	for k := range mt.Params {
+		keys[i] = k
+		i++
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		v := mt.Params[k]
 		fmt.Fprintf(&buf, ";%s=%s", k, EscapeString(v))
 	}
 	return mt.ContentType() + (&buf).String()

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -69,7 +69,7 @@ github.com/sigma/vmw-guestinfo/vmcheck
 # github.com/stretchr/testify v1.7.0
 ## explicit
 github.com/stretchr/testify/assert
-# github.com/vincent-petithory/dataurl v0.0.0-20160330182126-9a301d65acbb
+# github.com/vincent-petithory/dataurl v1.0.0
 ## explicit
 github.com/vincent-petithory/dataurl
 # github.com/vmware/vmw-guestinfo v0.0.0-20170707015358-25eff159a728


### PR DESCRIPTION
# Update dataurl module to v1.0.0

Upstream has created a tag to improve stability so we should use it.

## How to use

Run `make` and ensure the binary is built.

## Testing done

Couldn't really test this since `go test -v ./...` fails even before this change.