### PR TITLE
tests: Add base64 decoding test

### DIFF
--- a/tests/positive/files/file.go
+++ b/tests/positive/files/file.go
@@ -21,6 +21,7 @@ import (
 
 func init() {
 	register.Register(register.PositiveTest, CreateFileOnRoot())
+	register.Register(register.PositiveTest, CreateFileOnRootFromBase64())
 	register.Register(register.PositiveTest, UserGroupByID())
 	register.Register(register.PositiveTest, UserGroupByName())
 	register.Register(register.PositiveTest, ForceFileCreation())
@@ -42,6 +43,40 @@ func CreateFileOnRoot() types.Test {
 	      "filesystem": "root",
 	      "path": "/foo/bar",
 	      "contents": { "source": "data:,example%20file%0A" }
+	    }]
+	  }
+	}`
+	out[0].Partitions.AddFiles("ROOT", []types.File{
+		{
+			Node: types.Node{
+				Name:      "bar",
+				Directory: "foo",
+			},
+			Contents: "example file\n",
+		},
+	})
+	configMinVersion := "2.0.0"
+
+	return types.Test{
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
+	}
+}
+
+func CreateFileOnRootFromBase64() types.Test {
+	name := "Create Files on the Root Filesystem from base64 data"
+	in := types.GetBaseDisk()
+	out := types.GetBaseDisk()
+	config := `{
+	  "ignition": { "version": "$version" },
+	  "storage": {
+	    "files": [{
+	      "filesystem": "root",
+	      "path": "/foo/bar",
+	      "contents": { "source": "data:;base64,ZXhhbXBsZSBmaWxlCg==" }
 	    }]
 	  }
 	}`


### PR DESCRIPTION
The data URLs which are used are all in URL encoding, while users can
also use base64 encoded data URLs.
Add a test to make sure base64 decoding works as expected.


## How to use

Merge for the current branch. No need to port it to the Ignition v3 update branch when the upstream PR is merged https://github.com/coreos/ignition/pull/1283 (Edit: Merged upstream)

## Testing done

@tormath1 and I ran this here: `./build_blackbox_tests && sudo sh -c 'PATH=$PWD/bin/amd64:$PATH ./tests.test'` which worked for the added test but we found that there are some other broken tests, probably due to the test environment. Would be good to check if these failures are gone on the GitHub Action that the v3 update brings.