### PR TITLE
Fix imports to match vendored modules

### DIFF
--- a/internal/config/types/headers.go
+++ b/internal/config/types/headers.go
@@ -17,7 +17,7 @@ package types
 import (
 	"net/http"
 
-	"github.com/coreos/ignition/config/shared/errors"
+	"github.com/flatcar-linux/ignition/config/shared/errors"
 )
 
 // Parse generates standard net/http headers from the data in HTTPHeaders

--- a/internal/config/types/headers_test.go
+++ b/internal/config/types/headers_test.go
@@ -18,7 +18,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/coreos/ignition/config/shared/errors"
+	"github.com/flatcar-linux/ignition/config/shared/errors"
 )
 
 func equal(a, b []string) bool {


### PR DESCRIPTION
Otherwise the code didn't compile as is unless `make vendor` was done which pulled in coreos/ignition.