### PR TITLE
providers/azure: support Azure IMDS 

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@ jobs:
     name: test build
     strategy:
       matrix:
-        go-version: [1.15.x, 1.16.x, 1.17.x]
+        go-version: [1.15.x, 1.16.x, 1.17.x, 1.18.x]
     runs-on: ubuntu-latest
     steps:
     - name: Set up Go 1.x
@@ -30,13 +30,13 @@ jobs:
     - name: Run linter
       uses: golangci/golangci-lint-action@v2
       with:
-        version: v1.42.0
+        version: v1.45.0
         args: -E=gofmt --timeout=30m0s
   test-validate:
     name: test ignition-validate
     strategy:
       matrix:
-        go-version: [1.17.x]
+        go-version: [1.18.x]
         os: [macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/config/v3_1/types/headers_test.go
+++ b/config/v3_1/types/headers_test.go
@@ -15,7 +15,6 @@
 package types
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/flatcar-linux/ignition/v2/config/shared/errors"
@@ -133,7 +132,7 @@ func TestValidHeadersParse(t *testing.T) {
 	if err != nil {
 		t.Errorf("error during parsing valid headers: %v", err)
 	}
-	if !equal(parseHeaders[strings.Title("header1")], []string{"header1value"}) || !equal(parseHeaders[strings.Title("header2")], []string{"header2value"}) {
+	if !equal(parseHeaders["Header1"], []string{"header1value"}) || !equal(parseHeaders["Header2"], []string{"header2value"}) {
 		t.Errorf("parsed HTTP headers values are wrong")
 	}
 }
@@ -154,7 +153,7 @@ func TestDuplicateHeadersParse(t *testing.T) {
 	if err != nil {
 		t.Errorf("error during parsing valid headers: %v", err)
 	}
-	if !equal(parseHeaders[strings.Title("header1")], []string{"header1value", "header2value"}) {
+	if !equal(parseHeaders["Header1"], []string{"header1value", "header2value"}) {
 		t.Errorf("parsed HTTP headers values are wrong")
 	}
 }

--- a/config/v3_2/types/headers_test.go
+++ b/config/v3_2/types/headers_test.go
@@ -15,7 +15,6 @@
 package types
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/flatcar-linux/ignition/v2/config/shared/errors"
@@ -133,7 +132,7 @@ func TestValidHeadersParse(t *testing.T) {
 	if err != nil {
 		t.Errorf("error during parsing valid headers: %v", err)
 	}
-	if !equal(parseHeaders[strings.Title("header1")], []string{"header1value"}) || !equal(parseHeaders[strings.Title("header2")], []string{"header2value"}) {
+	if !equal(parseHeaders["Header1"], []string{"header1value"}) || !equal(parseHeaders["Header2"], []string{"header2value"}) {
 		t.Errorf("parsed HTTP headers values are wrong")
 	}
 }
@@ -154,7 +153,7 @@ func TestDuplicateHeadersParse(t *testing.T) {
 	if err != nil {
 		t.Errorf("error during parsing valid headers: %v", err)
 	}
-	if !equal(parseHeaders[strings.Title("header1")], []string{"header1value", "header2value"}) {
+	if !equal(parseHeaders["Header1"], []string{"header1value", "header2value"}) {
 		t.Errorf("parsed HTTP headers values are wrong")
 	}
 }

--- a/config/v3_3/types/headers_test.go
+++ b/config/v3_3/types/headers_test.go
@@ -15,7 +15,6 @@
 package types
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/flatcar-linux/ignition/v2/config/shared/errors"
@@ -133,7 +132,7 @@ func TestValidHeadersParse(t *testing.T) {
 	if err != nil {
 		t.Errorf("error during parsing valid headers: %v", err)
 	}
-	if !equal(parseHeaders[strings.Title("header1")], []string{"header1value"}) || !equal(parseHeaders[strings.Title("header2")], []string{"header2value"}) {
+	if !equal(parseHeaders["Header1"], []string{"header1value"}) || !equal(parseHeaders["Header2"], []string{"header2value"}) {
 		t.Errorf("parsed HTTP headers values are wrong")
 	}
 }
@@ -154,7 +153,7 @@ func TestDuplicateHeadersParse(t *testing.T) {
 	if err != nil {
 		t.Errorf("error during parsing valid headers: %v", err)
 	}
-	if !equal(parseHeaders[strings.Title("header1")], []string{"header1value", "header2value"}) {
+	if !equal(parseHeaders["Header1"], []string{"header1value", "header2value"}) {
 		t.Errorf("parsed HTTP headers values are wrong")
 	}
 }

--- a/config/v3_4_experimental/types/headers_test.go
+++ b/config/v3_4_experimental/types/headers_test.go
@@ -15,7 +15,6 @@
 package types
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/flatcar-linux/ignition/v2/config/shared/errors"
@@ -133,7 +132,7 @@ func TestValidHeadersParse(t *testing.T) {
 	if err != nil {
 		t.Errorf("error during parsing valid headers: %v", err)
 	}
-	if !equal(parseHeaders[strings.Title("header1")], []string{"header1value"}) || !equal(parseHeaders[strings.Title("header2")], []string{"header2value"}) {
+	if !equal(parseHeaders["Header1"], []string{"header1value"}) || !equal(parseHeaders["Header2"], []string{"header2value"}) {
 		t.Errorf("parsed HTTP headers values are wrong")
 	}
 }
@@ -154,7 +153,7 @@ func TestDuplicateHeadersParse(t *testing.T) {
 	if err != nil {
 		t.Errorf("error during parsing valid headers: %v", err)
 	}
-	if !equal(parseHeaders[strings.Title("header1")], []string{"header1value", "header2value"}) {
+	if !equal(parseHeaders["Header1"], []string{"header1value", "header2value"}) {
 		t.Errorf("parsed HTTP headers values are wrong")
 	}
 }

--- a/internal/providers/azure/azure.go
+++ b/internal/providers/azure/azure.go
@@ -17,12 +17,16 @@
 package azure
 
 import (
+	"encoding/base64"
 	"fmt"
 	"io/ioutil"
+	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"time"
 
+	"github.com/flatcar-linux/ignition/v2/config/shared/errors"
 	"github.com/flatcar-linux/ignition/v2/config/v3_4_experimental/types"
 	execUtil "github.com/flatcar-linux/ignition/v2/internal/exec/util"
 	"github.com/flatcar-linux/ignition/v2/internal/log"
@@ -56,9 +60,73 @@ const (
 	CDS_FSTYPE_UDF = "udf"
 )
 
-// FetchConfig wraps FetchOvfDevice to implement the platform.NewFetcher interface.
+var (
+	imdsUserdataURL = url.URL{
+		Scheme:   "http",
+		Host:     "169.254.169.254",
+		Path:     "metadata/instance/compute/userData",
+		RawQuery: "api-version=2021-01-01&format=text",
+	}
+)
+
+// FetchConfig wraps fetchFromAzureMetadata to implement the platform.NewFetcher interface.
 func FetchConfig(f *resource.Fetcher) (types.Config, report.Report, error) {
+	return fetchFromAzureMetadata(f)
+}
+
+// fetchFromAzureMetadata first tries to fetch userData from IMDS then fallback on customData in case
+// of empty config.
+func fetchFromAzureMetadata(f *resource.Fetcher) (types.Config, report.Report, error) {
+	// fetch-offline is not supported since we first try to get config from Azure IMDS.
+	// this config fetching can only happen during fetch stage.
+	if f.Offline {
+		return types.Config{}, report.Report{}, resource.ErrNeedNet
+	}
+
+	logger := f.Logger
+
+	// we first try to fetch config from IMDS, in case of failure we fallback on the custom data.
+	userData, err := fetchFromIMDS(f)
+	if err == nil {
+		logger.Info("config has been read from IMDS userdata")
+		return util.ParseConfig(logger, userData)
+	}
+
+	if err != errors.ErrEmpty {
+		return types.Config{}, report.Report{}, err
+	}
+
+	logger.Debug("failed to retrieve userdata from IMDS, falling back to custom data: %v", err)
 	return FetchFromOvfDevice(f, []string{CDS_FSTYPE_UDF})
+}
+
+// fetchFromIMDS requests the Azure IMDS to fetch userdata and decode it.
+func fetchFromIMDS(f *resource.Fetcher) ([]byte, error) {
+	headers := make(http.Header)
+	headers.Set("Metadata", "true")
+
+	data, err := f.FetchToBuffer(imdsUserdataURL, resource.FetchOptions{Headers: headers})
+	if err != nil {
+		return nil, fmt.Errorf("fetching to buffer: %w", err)
+	}
+
+	n := len(data)
+
+	if n == 0 {
+		return nil, errors.ErrEmpty
+	}
+
+	// data is base64 encoded by the IMDS
+	userData := make([]byte, base64.StdEncoding.DecodedLen(n))
+
+	// we keep the number of bytes written to return [:l] only.
+	// otherwise last byte will be 0x00 which makes fail the JSON's unmarshalling.
+	l, err := base64.StdEncoding.Decode(userData, data)
+	if err != nil {
+		return nil, fmt.Errorf("decoding userdata: %w", err)
+	}
+
+	return userData[:l], nil
 }
 
 // FetchFromOvfDevice has the return signature of platform.NewFetcher. It is
@@ -82,6 +150,7 @@ func FetchFromOvfDevice(f *resource.Fetcher, ovfFsTypes []string) (types.Config,
 					if err != nil {
 						logger.Debug("failed to retrieve config from device %q: %v", dev, err)
 					} else {
+						logger.Info("config has been read from custom data")
 						return util.ParseConfig(logger, rawConfig)
 					}
 				}


### PR DESCRIPTION
In this PR, we add support for Azure IMDS on top of existing CustomData. If it fails to fetch base64 encoded userData Ignition will fallback on CustomData.

`provider/azure: try to fetch user-data from IMDS` could be upstreamed once the tests / validation are OK.

## Note for reviewers

* the last two commits: `config: update headers_test to stop using strings.Title()` and `ci: add testing with Go 1.18` are from the upstream - it makes the CI happy.
