### PR TITLE
feat/ovh-baremetal

### DIFF
--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -152,6 +152,10 @@ func init() {
 		name:  "zvm",
 		fetch: zvm.FetchConfig,
 	})
+	configs.Register(Config{
+		name:  "ovh-baremetal",
+		fetch: openstack.FetchConfig,
+	})
 }
 
 func Get(name string) (config Config, ok bool) {

--- a/internal/providers/openstack/openstack.go
+++ b/internal/providers/openstack/openstack.go
@@ -73,11 +73,11 @@ func FetchConfig(f *resource.Fetcher) (types.Config, report.Report, error) {
 	}
 
 	go dispatch("config drive (config-2)", func() ([]byte, error) {
-		return fetchConfigFromDevice(f.Logger, ctx, filepath.Join(distro.DiskByLabelDir(), "config-2"))
+		return FetchConfigFromDevice(f.Logger, ctx, filepath.Join(distro.DiskByLabelDir(), "config-2"))
 	})
 
 	go dispatch("config drive (CONFIG-2)", func() ([]byte, error) {
-		return fetchConfigFromDevice(f.Logger, ctx, filepath.Join(distro.DiskByLabelDir(), "CONFIG-2"))
+		return FetchConfigFromDevice(f.Logger, ctx, filepath.Join(distro.DiskByLabelDir(), "CONFIG-2"))
 	})
 
 	go dispatch("metadata service", func() ([]byte, error) {
@@ -97,7 +97,7 @@ func fileExists(path string) bool {
 	return (err == nil)
 }
 
-func fetchConfigFromDevice(logger *log.Logger, ctx context.Context, path string) ([]byte, error) {
+func FetchConfigFromDevice(logger *log.Logger, ctx context.Context, path string) ([]byte, error) {
 	for !fileExists(path) {
 		logger.Debug("config drive (%q) not found. Waiting...", path)
 		select {


### PR DESCRIPTION
# Add provider ovh-baremetal

We use flatcar on OVH baremetal which uses openstack tools partly: notably the user_data which is ignored if we use the metal provider.

Add this and later OEM things in coreos-overlay (in development).

Simplified ibmcloud provider too which uses openstack but is a little different.

## How to use

Just use --platform=ovh-baremetal

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
