### PR TITLE
fix: improve example username

### DIFF
--- a/doc/examples.md
+++ b/doc/examples.md
@@ -270,7 +270,7 @@ Users can be added to an OS with the `passwd.users` key which takes a list of ob
   "passwd": {
     "users": [
       {
-        "name": "systemUser",
+        "name": "example-user",
         "passwordHash": "$superSecretPasswordHash.",
         "sshAuthorizedKeys": [
           "ssh-rsa veryLongRSAPublicKey"


### PR DESCRIPTION
I was lazy and copied the example and that user name is not allowed out of the box:

![image](https://user-images.githubusercontent.com/6224096/230793455-2b292b9b-d04f-4c8e-8bd8-c578a3e00caa.png)