### PR TITLE
replace ajeddeloh/go-json with coreos/go-json

### DIFF
--- a/config/util/parsingErrors.go
+++ b/config/util/parsingErrors.go
@@ -22,7 +22,7 @@ import (
 	"github.com/flatcar/ignition/config/v2_4/types"
 	"github.com/flatcar/ignition/config/validate/report"
 
-	json "github.com/ajeddeloh/go-json"
+	json "github.com/coreos/go-json"
 	"go4.org/errorutil"
 )
 

--- a/config/v1/config.go
+++ b/config/v1/config.go
@@ -21,7 +21,7 @@ import (
 	"github.com/flatcar/ignition/config/validate"
 	"github.com/flatcar/ignition/config/validate/report"
 
-	json "github.com/ajeddeloh/go-json"
+	json "github.com/coreos/go-json"
 )
 
 func Parse(rawConfig []byte) (types.Config, report.Report, error) {

--- a/config/v2_0/config.go
+++ b/config/v2_0/config.go
@@ -16,12 +16,12 @@ package v2_0
 
 import (
 	"github.com/flatcar/ignition/config/shared/errors"
-	"github.com/flatcar/ignition/config/v1"
+	v1 "github.com/flatcar/ignition/config/v1"
 	"github.com/flatcar/ignition/config/v2_0/types"
 	"github.com/flatcar/ignition/config/validate"
 	"github.com/flatcar/ignition/config/validate/report"
 
-	json "github.com/ajeddeloh/go-json"
+	json "github.com/coreos/go-json"
 	"github.com/coreos/go-semver/semver"
 )
 

--- a/config/v2_1/config.go
+++ b/config/v2_1/config.go
@@ -22,7 +22,7 @@ import (
 	"github.com/flatcar/ignition/config/validate"
 	"github.com/flatcar/ignition/config/validate/report"
 
-	json "github.com/ajeddeloh/go-json"
+	json "github.com/coreos/go-json"
 )
 
 func Parse(rawConfig []byte) (types.Config, report.Report, error) {

--- a/config/v2_2/config.go
+++ b/config/v2_2/config.go
@@ -21,7 +21,7 @@ import (
 	"github.com/flatcar/ignition/config/validate"
 	"github.com/flatcar/ignition/config/validate/report"
 
-	json "github.com/ajeddeloh/go-json"
+	json "github.com/coreos/go-json"
 	"github.com/coreos/go-semver/semver"
 )
 

--- a/config/v2_3/config.go
+++ b/config/v2_3/config.go
@@ -21,7 +21,7 @@ import (
 	"github.com/flatcar/ignition/config/validate"
 	"github.com/flatcar/ignition/config/validate/report"
 
-	json "github.com/ajeddeloh/go-json"
+	json "github.com/coreos/go-json"
 	"github.com/coreos/go-semver/semver"
 )
 

--- a/config/v2_4/config.go
+++ b/config/v2_4/config.go
@@ -21,7 +21,7 @@ import (
 	"github.com/flatcar/ignition/config/validate"
 	"github.com/flatcar/ignition/config/validate/report"
 
-	json "github.com/ajeddeloh/go-json"
+	json "github.com/coreos/go-json"
 	"github.com/coreos/go-semver/semver"
 )
 

--- a/config/validate/astjson/node.go
+++ b/config/validate/astjson/node.go
@@ -17,7 +17,7 @@ package astjson
 import (
 	"io"
 
-	json "github.com/ajeddeloh/go-json"
+	json "github.com/coreos/go-json"
 	"github.com/flatcar/ignition/config/validate/astnode"
 	"go4.org/errorutil"
 )

--- a/config/validate/validate.go
+++ b/config/validate/validate.go
@@ -21,7 +21,7 @@ import (
 	"reflect"
 	"strings"
 
-	json "github.com/ajeddeloh/go-json"
+	json "github.com/coreos/go-json"
 	"github.com/flatcar/ignition/config/validate/astjson"
 	"github.com/flatcar/ignition/config/validate/astnode"
 	"github.com/flatcar/ignition/config/validate/report"

--- a/config/validate/validate_test.go
+++ b/config/validate/validate_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/coreos/go-semver/semver"
 	"github.com/stretchr/testify/assert"
 
-	json "github.com/ajeddeloh/go-json"
+	json "github.com/coreos/go-json"
 	"github.com/flatcar/ignition/config/shared/errors"
 	"github.com/flatcar/ignition/config/util"
 	"github.com/flatcar/ignition/config/validate/astjson"

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/flatcar/ignition
 go 1.16
 
 require (
-	github.com/ajeddeloh/go-json v0.0.0-20160803184958-73d058cf8437
 	github.com/aws/aws-sdk-go v1.8.39
+	github.com/coreos/go-json v0.0.0-20231102161613-e49c8866685a
 	github.com/coreos/go-semver v0.1.0
 	github.com/coreos/go-systemd v0.0.0-20181031085051-9002847aa142
 	github.com/go-ini/ini v1.25.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
-github.com/ajeddeloh/go-json v0.0.0-20160803184958-73d058cf8437 h1:gZCtZ+Hh/e3CGEX8q/yAcp8wWu5ZS6NMk6VGzpQhI3s=
-github.com/ajeddeloh/go-json v0.0.0-20160803184958-73d058cf8437/go.mod h1:otnto4/Icqn88WCcM4bhIJNSgsh9VLBuspyyCfvof9c=
 github.com/aws/aws-sdk-go v1.8.39 h1:YUHeSL8ksAt063XvBxH94mIPHd0bh+dbyQR141Hb9e0=
 github.com/aws/aws-sdk-go v1.8.39/go.mod h1:ZRmQr0FajVIyZ4ZzBYKG5P3ZqPz9IHG41ZoMu1ADI3k=
+github.com/coreos/go-json v0.0.0-20231102161613-e49c8866685a h1:QimUZQ6Au5wFKKkPMmdoXen+CNR66lXt/76AQLBltS0=
+github.com/coreos/go-json v0.0.0-20231102161613-e49c8866685a/go.mod h1:rcFZM3uxVvdyNmsAV2jopgPD1cs5SPWJWU5dOz2LUnw=
 github.com/coreos/go-semver v0.1.0 h1:/7eIWhjNpsljQCSU+5NaZzu7HmMvoWnMqOmNZljz1f0=
 github.com/coreos/go-semver v0.1.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd v0.0.0-20181031085051-9002847aa142 h1:3jFq2xL4ZajGK4aZY8jz+DAF0FHjI51BXjjSwCzS1Dk=


### PR DESCRIPTION
# replace ajeddeloh/go-json with coreos/go-json

The old repository does not exist anymore and is redirecting to github.com/coreos/go-json. At the moment, every consumer of this project has to maintain a custom `rewrite` directive in their go.mod, this PR would be one step to get rid of that.

This will effectively raise the minimum Go version to Go 1.18 ( https://github.com/coreos/go-json/blob/main/go.mod#L3 ).